### PR TITLE
Dockerize EEL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.8-alpine
+
+ENV BUILD_PACKAGES="build-base git"
+
+WORKDIR /go/src/github.com/Comcast/eel
+COPY . ./
+
+RUN apk update && \
+    apk upgrade && \
+    apk add $BUILD_PACKAGES && \
+    go get -u github.com/Comcast/eel && \
+    go build -o bin/eel
+
+EXPOSE 8080
+CMD ./bin/dockereel.sh
+

--- a/README.md
+++ b/README.md
@@ -60,6 +60,30 @@ go build -o bin/eel
 ./bin/starteel.sh
 ```
 
+## Docker way
+
+Docker 1.13+ verified.
+
+Build a dev image
+
+```
+docker build -t eel:dev .
+```
+
+Run an instance
+
+```
+docker run --rm -p 8080:8080 --name eel-dev eel:dev
+```
+
+The command above will utilize port `8080` of your host.
+You can change it to any other port via `-p ANYOTHERPORT:8080`
+
+To pass parameters to `eel` you can use `EEL_PARAMS` env variable, e.g.
+```
+docker run --rm -e "EEL_PARAMS=-loglevel error" -p 8080:8080 --name eel-dev eel:dev
+```
+
 ## A Simple Example
 
 Transformation handlers are used to tell EEL if and how to process JSON events it receives and where to

--- a/bin/dockereel.sh
+++ b/bin/dockereel.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Copyright 2017 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+./bin/eel $EEL_PARAMS


### PR DESCRIPTION
This is a simple addition to make it easy start using `docker`

It is still not ready for public container registry but can be used with comfort for dev needs w/o any `golang` infra required