### PR TITLE
Xrules 10493

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This `CHANGELOG.md` implements the spirit of http://keepachangelog.com/.
 
 ## [1.16](https://github.com/Comcast/eel/compare/v1.15...dev) - [Unreleased]
 
+### Fixed
+* XRULES-10493: support escape character in function parameters
+
 ## [1.15](https://github.com/Comcast/eel/compare/v1.14...v1.15) - 2017-12-01
 
 ### Fixed

--- a/doc/jpath.md
+++ b/doc/jpath.md
@@ -109,3 +109,12 @@ Output event:
 ```
 { "message" : "User email is {{email}}" }
 ```
+
+To escape individual characters such as single quote inside of a function parameter, use the 
+backslash character.
+
+Example:
+
+```
+{{ident('this wasn\'t working in earlier versions')}}
+```

--- a/jtl/lexer.go
+++ b/jtl/lexer.go
@@ -243,8 +243,15 @@ func lexParam(l *lexer) stateFn {
 			return l.errorf("unclosed param at %d: %s\n", l.pos, l.input)
 		case r == '{':
 			bc++
+			break
 		case r == '}':
 			bc--
+			break
+		case r == '\\':
+			// skip over character following escape character
+			l.next()
+			l.next()
+			break
 		case r == '\'' && bc == 0:
 			l.emit(lexItemParam)
 			return lexParamList
@@ -268,11 +275,18 @@ func lexParamList(l *lexer) stateFn {
 			return l.errorf("unclosed function at %d: %s\n", l.pos, l.input)
 		case isWhitespace(r):
 			l.ignore()
+			break
 		case r == ')':
 			l.emit(lexItemRightBracket)
 			return lexRightMeta
 		case r == ',':
 			l.ignore()
+			break
+		case r == '\\':
+			// skip over character following escape character
+			l.next()
+			l.next()
+			break
 		case r == '\'':
 			return lexParam
 		}

--- a/jtl/parser.go
+++ b/jtl/parser.go
@@ -102,7 +102,7 @@ func (a *JExprItem) GetD3Json(cur *JExprD3Node) *JExprD3Node {
 	return cur
 }
 
-// parse parses a single lebel of a jpath expression. Returns an error (if any) or nil.
+// parse parses a single jpath expression. Returns an error (if any) or nil.
 func (a *JExprItem) parse(expr string) error {
 	_, c := lex("", expr)
 	var f *JExprItem
@@ -121,7 +121,7 @@ func (a *JExprItem) parse(expr string) error {
 			a.kids = append(a.kids, t)
 		case lexItemParam:
 			if f != nil {
-				p := newJExprItem(astParam, item.val, f)
+				p := newJExprItem(astParam, item.val, f) //strings.Replace(item.val, "\\", "", -1), f)
 				f.kids = append(f.kids, p)
 			} else {
 				return errors.New("param without function")
@@ -270,7 +270,7 @@ func (a *JExprItem) optimizeConditional(ctx Context, doc *JDoc) (*JExprItem, err
 		if len(a.kids) != 3 {
 			ctx.Log().Error("error_type", "parser", "cause", "wrong_number_of_parameters", "type", a.typ, "val", a.val, "num_params", len(a.kids), "error", "wrong number of parameters")
 			stats.IncErrors()
-			AddError(ctx, RuntimeError{fmt.Sprintf("iwrong number of parameters"), "ifte", nil})
+			AddError(ctx, RuntimeError{fmt.Sprintf("wrong number of parameters"), "ifte", nil})
 			return nil, errors.New("ifte has wrong number of parameters")
 		}
 		if a.mom == nil {
@@ -667,6 +667,11 @@ func (a *JExprItem) Execute(ctx Context, doc *JDoc) interface{} {
 		}
 	}
 	a.print(0, "AST")
+	// remove escape indicators in final step
+	switch a.val.(type) {
+	case string:
+		a.val = strings.Replace(a.val.(string), "\\", "", -1)
+	}
 	return a.val
 }
 
@@ -682,5 +687,10 @@ func (a *JExprItem) ExecuteDebug(ctx Context, doc *JDoc) (interface{}, [][][]str
 		}
 	}
 	a.print(0, "AST")
+	// remove escape indicators in final step
+	switch a.val.(type) {
+	case string:
+		a.val = strings.Replace(a.val.(string), "\\", "", -1)
+	}
 	return a.val, trees
 }

--- a/test/misc_test.go
+++ b/test/misc_test.go
@@ -1219,6 +1219,24 @@ func TestParserWhiteSpace(t *testing.T) {
 	}
 }
 
+func TestEscapingSingleQuotes(t *testing.T) {
+	initTests("../config-handlers")
+	e1, err := NewJDocFromString(event1)
+	if err != nil {
+		t.Fatal("could not get event1")
+	}
+	test := `{{ident('{{ident('{{ident('this isn\'t breaking any more')}}')}}')}}`
+	jexpr, err := NewJExpr(test)
+	if err != nil {
+		t.Errorf("parsing error: %s\n", err.Error())
+	}
+	result := jexpr.Execute(Gctx, e1)
+	expected := `this isn't breaking any more`
+	if result.(string) != expected {
+		t.Errorf("wrong parsing result: %v expected: %s\n", result, expected)
+	}
+}
+
 func TestParserDeepNesting(t *testing.T) {
 	initTests("../config-handlers")
 	e1, err := NewJDocFromString(event1)


### PR DESCRIPTION
<!-- The above title is in the format: -->
<!-- XRULES-XXXX: <SHORT DESCRIPTION GOES HERE>  -->
XRULES-10493 Allow Escape Characters inside of Function Parameters
## Types of changes
<!--- What types of changes does your code introduce? -->
<!-- Change the checkbox to `[x]` for all items that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Summary Of Changes:
<!--- Describe your changes in detail if needed in addition to `CHANGELOG.md` info -->
Support backslash as escape character inside of function parameters. 
Example:
```
{{ident('this wasn\'t working in earlier versions')}}
```

### Added
-

### Changed
-

### Fixed
-


## I Have Done The Following
<!-- Go over all the following points. -->
<!-- Change the checkbox to `[x]` for all the tasks that are completed. -->
- [x] Updated the `CHANGELOG.md` file with the above summary of changes.
- [x] I have updated the documentation accordingly.
- [x] Have added new unit tests to test any new code.
- [x] Have not reduced code coverage since the last commit (`go test -cover`).
- [x] Confirmed that all existing and new tests passed.


## Reviewers
@holidaymike 

